### PR TITLE
German pressrelease name

### DIFF
--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -85,6 +85,8 @@
   "contactform_send_info": "Wir werden uns Zeitnah bei Ihnen melden!",
   "contactform_error_header": "Es ist ein Fehler aufgetreten!",
   "about_title": "Informationen",
+  "pressreview": "Pressespiegel",
+  "date": "Datum",
   "about_sub_title1": "Stoppt die Zensurmaschine – Rettet das Internet!",
   "about_sub_text1": "Wir haben das erste wichtige Etappenziel im Kampf gegen die neue Urheberrechtsreform im digitalen Binnenmarkt erreicht. Zunächst wurde diese am 20. Juni vom Rechtsausschuss des EU-Parlaments abgesegnet, doch am 05. Juli entschied sich das Plenum im Rahmen seiner Abstimmung dagegen.",
   "about_sub_title2": "Bedeutung und neue Ziele",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -84,6 +84,8 @@
   "contactform_send_info": "We will get back to you shortly",
   "contactform_error_header": "An error occured.",
   "about_title": "About",
+  "pressreview": "Pressreview",
+  "date": "Date",
   "about_sub_title1": "Stop the censorship machine - save the internet!",
   "about_sub_text1": "The internet as you know it is in danger! The European Parliament is currently planning to tighten the copyright law, which would massively restrict your freedom on the internet.",
   "about_sub_title2": "What awaits you:",

--- a/src/views/layout/header.ejs
+++ b/src/views/layout/header.ejs
@@ -54,7 +54,7 @@
             <li><a class="nav-link" href="/about-us"><%= __('about_us_heading') %></a></li>
             <li><a class="nav-link" href="/gallery"><%= __('gallery_title') %></a></li>
             <li><a class="nav-link" href="/about"><%= __('about_title') %></a></li>
-            <% if(currentLanguage == "de") { %><li><a class="nav-link" href="/pressreview">Pressemitteilung</a></li><% } %>
+            <% if(currentLanguage == "de") { %><li><a class="nav-link" href="/pressreview"><%= __('pressreview') %></a></li><% } %>
         </ul>
     </nav>
     <div class="language-picker mr-2">

--- a/src/views/pressreview.ejs
+++ b/src/views/pressreview.ejs
@@ -1,14 +1,14 @@
 <%- include('layout/header'); -%>
     <div class="section container">
         <h1 class="mb-16">
-            Pressemitteilungen
+            <%= __('pressreview') %>
         </h1>
 
         <table class="w-full text-left table-collapse">
             <thead>
                 <tr>
-                    <th class="text-sm p-2 bg-grey-lightest">Datum</th>
-                    <th class="text-sm p-2 bg-grey-lightest">Pressemitteilung</th>
+                    <th class="text-sm p-2 bg-grey-lightest"><%= __('date') %></th>
+                    <th class="text-sm p-2 bg-grey-lightest"><%= __('pressreview') %></th>
                 </tr>
             </thead>
             <tbody class="align-baseline">

--- a/src/views/pressreview.ejs
+++ b/src/views/pressreview.ejs
@@ -7,8 +7,8 @@
         <table class="w-full text-left table-collapse">
             <thead>
                 <tr>
-                    <th class="text-sm p-2 bg-grey-lightest"><%= __('date') %></th>
-                    <th class="text-sm p-2 bg-grey-lightest"><%= __('pressreview') %></th>
+                    <th class="text-sm p-2 text-black bg-grey-lightest"><%= __('date') %></th>
+                    <th class="text-sm p-2 text-black bg-grey-lightest"><%= __('pressreview') %></th>
                 </tr>
             </thead>
             <tbody class="align-baseline">


### PR DESCRIPTION
Fixed pressrelease name:

- Moved hard coded texts on `/pressreview` route to translation file
- Changed "Pressemitteilung" to "Pressespiegel"
- Made text readble again (see gif below)

![d770e3db3d](https://user-images.githubusercontent.com/22935000/44426108-13260d00-a58e-11e8-9b4a-af9c8091a9d8.gif)

This resolves https://github.com/savetheinternetinfo/website/issues/116