### PR TITLE
Fix error while installing npm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4969,9 +4969,9 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"


### PR DESCRIPTION
Version 5.1.2 of har-validator was renamed to 5.1.3 and therefore the
old package is not available anymore and causes an 404 error upon
retrieval.

See https://github.com/ahmadnassri/node-har-validator/issues/113