### PR TITLE
Add demo on 23rd March in Germany, Fürth to map

### DIFF
--- a/mapcoords.json
+++ b/mapcoords.json
@@ -26,6 +26,30 @@
         }
      },
      {
+        "type":"Feature",
+        "properties":[
+           {
+              "fa_icon":"fa-map-marker",
+              "value":"Fürth - Grüner Markt"
+           },
+           {
+              "fa_icon":"fa-clock-o",
+              "value":"23.03.2019 13:00"
+           },
+           {
+              "fa_icon":"fb_event",
+              "value":"<a href=\"https://www.facebook.com/events/794342270950440/\">Facebook Event</a>"
+           }
+        ],
+        "geometry":{
+           "type":"Point",
+           "coordinates":[
+              10.9864408,
+              49.4796045
+           ]
+        }
+      },
+     {
       "type":"Feature",
       "properties":[
          {


### PR DESCRIPTION
Add marker for a demo on 23rd March in Fürth, Germany to map.

Announcement (besides Facebook event linked to marker): https://twitter.com/dieparteifuerth/status/1101547901195599872

Disclaimer: I'm not affiliated with the organisators of the demo.